### PR TITLE
feat: 设置激活主动点击的菜单，点击后的滚动过程中不进行激活序号的更新

### DIFF
--- a/packages/scroll-active/src/ScrollActive.ts
+++ b/packages/scroll-active/src/ScrollActive.ts
@@ -14,6 +14,8 @@ export default class ScrollActive {
 
     private targetList: HTMLElement[] = []; // 页面中要监听的所有元素
 
+    private isScrolling = false; // 当前是否处于鼠标点击菜单后的滚动状态
+
     constructor(options: Partial<ActiveOptions> = {}) {
         this.options = Object.assign({}, new ActiveOptions(), options);
         this.initialize();
@@ -40,14 +42,20 @@ export default class ScrollActive {
         const el = ev.currentTarget as HTMLElement;
         const id = el.getAttribute(ATTR_SCROLL_ACTIVE) as string;
         const targetIndex = this.idList.indexOf(id);
-
         const targetEl = this.targetList[targetIndex];
         if (!targetEl) {
             return;
         }
 
-        tweenScroll(getAbsPoint(targetEl).y - this.options.offset, 500);
+        this.isScrolling = true;
+        tweenScroll(getAbsPoint(targetEl).y - this.options.offset, 500, () => {
+            // 滚动完毕 清空flag
+            this.isScrolling = false;
+        });
         this.options.hash && pushState(id);
+
+        // 激活当前点击过的锚点菜单状态
+        this.update(targetIndex);
     };
 
     private handleScroll = () => {
@@ -66,7 +74,11 @@ export default class ScrollActive {
                 break;
             }
         }
-        this.update(activeIndex);
+
+        // 非点击行为的时候触发滚动更新
+        if (!this.isScrolling) {
+            this.update(activeIndex);
+        }
     };
 
     private update(activeIndex: number) {

--- a/packages/scroll-active/src/lib/utils.ts
+++ b/packages/scroll-active/src/lib/utils.ts
@@ -45,9 +45,10 @@ let task: Task<any>;
  * @export
  * @param {number} to 目标位置
  * @param {number} duration 完成动作耗时
+ * @param {function} done 完成动作后的回调
  * @returns {void}
  */
-export function tweenScroll(to: number, duration: number): void {
+export function tweenScroll(to: number, duration: number, done?: () => void): void {
     if (task) {
         task.dispose();
     }
@@ -66,7 +67,8 @@ export function tweenScroll(to: number, duration: number): void {
         },
         onUpdate({ y }) {
             setScrollTop(y);
-        }
+        },
+        done
     });
 }
 


### PR DESCRIPTION
目前的功能上 激活锚点菜单高亮效果是由滚动高度控制，但是这会导致一个问题：用户在点击最后一个锚点菜单的时候，没有办法正确高亮到最后一个菜单（除非在激活元素下方还有冗余空间供其滚动到可触发高亮的位置）

这里的改动只设置了单个菜单的高亮，如果需要联动多个菜单绑定点击高亮的话还有改进空间（不过我觉得应该不会有一个页面同时出现多个锚点菜单的情况吧？）